### PR TITLE
Add game table and casino type column

### DIFF
--- a/database_schema.sql
+++ b/database_schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE casinos (
     id INT AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(255) NOT NULL,
     slug VARCHAR(255) UNIQUE NOT NULL,
-    type ENUM('online', 'sweepstakes', 'crypto', 'live') NOT NULL DEFAULT 'online',
+    casino_type ENUM('online', 'sweepstakes', 'crypto', 'live') NOT NULL DEFAULT 'online',
     rating DECIMAL(2,1) NOT NULL DEFAULT 0.0,
     bonus TEXT,
     bonus_value DECIMAL(10,2) DEFAULT 0.00,
@@ -39,7 +39,7 @@ CREATE TABLE casinos (
     
     INDEX idx_status (status),
     INDEX idx_rating (rating),
-    INDEX idx_type (type),
+    INDEX idx_casino_type (casino_type),
     INDEX idx_featured (featured),
     INDEX idx_sort_order (sort_order)
 );
@@ -70,6 +70,23 @@ CREATE TABLE reviews (
     FOREIGN KEY (casino_id) REFERENCES casinos(id) ON DELETE CASCADE,
     INDEX idx_casino_id (casino_id),
     INDEX idx_status (status),
+    INDEX idx_rating (rating)
+);
+
+-- Games table - stores casino games offered by each casino
+CREATE TABLE games (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    casino_id INT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    game_type ENUM('slots', 'roulette', 'blackjack', 'keno', 'other') NOT NULL DEFAULT 'other',
+    rating DECIMAL(2,1) NOT NULL DEFAULT 0.0,
+    description TEXT,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    FOREIGN KEY (casino_id) REFERENCES casinos(id) ON DELETE CASCADE,
+    INDEX idx_casino_id (casino_id),
+    INDEX idx_game_type (game_type),
     INDEX idx_rating (rating)
 );
 
@@ -172,7 +189,7 @@ CREATE TABLE page_views (
 );
 
 -- Insert sample data
-INSERT INTO casinos (name, slug, type, rating, bonus, features, description, logo, status, featured) VALUES
+INSERT INTO casinos (name, slug, casino_type, rating, bonus, features, description, logo, status, featured) VALUES
 ('Crown Coins', 'crown-coins', 'sweepstakes', 4.9, 'Get 200% More Coins on First Purchase - 1.5 Million CC + 75 SC', 
  '["24/7 support, unlike most competitors", "Only sweeps site with 4.7★ iOS app", "Offers Relax Gaming, Pragmatic Play"]',
  'Crown Coins Casino stands out as one of the premier sweepstakes casinos in the market, offering an exceptional gaming experience with a focus on player satisfaction and security.',
@@ -184,9 +201,17 @@ INSERT INTO casinos (name, slug, type, rating, bonus, features, description, log
  'https://via.placeholder.com/120x60/2196F3/white?text=Stake', 'active', TRUE),
 
 ('Jackpota', 'jackpota', 'online', 4.6, '80,000 Gold Coins + 40 Sweeps Coins and 75 Free Spins',
- '["A 200M jackpot on every game", "Get 1,500 free gold coins daily", "Enjoy 700+ exciting games"]',
- 'Jackpota provides an exciting gaming environment with massive jackpots and daily rewards.',
- 'https://via.placeholder.com/120x60/FF9800/white?text=Jackpota', 'active', TRUE);
+'["A 200M jackpot on every game", "Get 1,500 free gold coins daily", "Enjoy 700+ exciting games"]',
+'Jackpota provides an exciting gaming environment with massive jackpots and daily rewards.',
+'https://via.placeholder.com/120x60/FF9800/white?text=Jackpota', 'active', TRUE);
+
+-- Insert sample games
+INSERT INTO games (casino_id, name, game_type, rating) VALUES
+(1, 'Online slots', 'slots', 4.5),
+(1, 'Online roulette', 'roulette', 4.2),
+(1, 'Online blackjack', 'blackjack', 4.0),
+(1, 'Online keno', 'keno', 3.8),
+(1, 'All casino games', 'other', 4.3);
 
 -- Insert sample categories
 INSERT INTO categories (name, slug, description, icon, sort_order) VALUES

--- a/index.html
+++ b/index.html
@@ -287,6 +287,44 @@
         </div>
     </section>
 
+    <!-- Casino Games Section -->
+    <section class="casino-games">
+        <div class="container">
+            <h2>Casino Games</h2>
+            <table class="info-table">
+                <tbody>
+                    <tr><td>Online slots</td></tr>
+                    <tr><td>Online roulette</td></tr>
+                    <tr><td>Online blackjack</td></tr>
+                    <tr><td>Online keno</td></tr>
+                    <tr><td>All casino games</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    <!-- Payment Options Section -->
+    <section class="payment-options">
+        <div class="container">
+            <h2>Payment Options</h2>
+            <table class="info-table">
+                <tbody>
+                    <tr><td>Fastest withdrawals</td></tr>
+                    <tr><td>Banking options</td></tr>
+                    <tr><td>Crypto casinos</td></tr>
+                    <tr><td>Best casino payment methods</td></tr>
+                    <tr><td>PayPal casinos</td></tr>
+                    <tr><td>CashApp casinos</td></tr>
+                    <tr><td>Skrill casinos</td></tr>
+                    <tr><td>Debit card casinos</td></tr>
+                    <tr><td>eCheck casinos</td></tr>
+                    <tr><td>Google Pay casinos</td></tr>
+                    <tr><td>Apple Pay casinos</td></tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
     <!-- Footer -->
     <footer class="footer">
         <div class="container">


### PR DESCRIPTION
## Summary
- Add `casino_type` field and index to casinos table
- Introduce new `games` table with game type and rating, plus sample game entries
- Display casino games and payment options tables on homepage

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a20ccb1ad48332ab9b70e84c5e4da9