### PR TITLE
Add PHP endpoint and frontend logic for casino data

### DIFF
--- a/fetch_casinos.php
+++ b/fetch_casinos.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Simple endpoint that returns casinos and games in JSON format.
+ */
+
+require_once __DIR__ . '/includes/config.php';
+
+header('Content-Type: application/json');
+
+try {
+    $db = Database::getInstance()->getConnection();
+
+    // Fetch active casinos
+    $casinoStmt = $db->query("SELECT id, name, casino_type AS type, rating, bonus, features, description, logo FROM casinos WHERE status = 'active'");
+    $casinos = $casinoStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    // Fetch games for all casinos
+    $gameStmt = $db->query("SELECT casino_id, name FROM games ORDER BY id");
+    $games = $gameStmt->fetchAll(PDO::FETCH_ASSOC);
+
+    echo json_encode([
+        'casinos' => $casinos,
+        'games' => $games,
+        'totalCount' => count($casinos)
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['error' => 'Database error']);
+}
+

--- a/includes/config.php
+++ b/includes/config.php
@@ -5,7 +5,7 @@
 
 // Database Configuration
 define('DB_HOST', 'localhost');
-define('DB_NAME', 'casino_reviews');
+define('DB_NAME', 'casino_db');
 define('DB_USER', 'your_username');
 define('DB_PASS', 'your_password');
 define('DB_CHARSET', 'utf8mb4');

--- a/index.html
+++ b/index.html
@@ -130,96 +130,7 @@
             </div>
             
             <div class="casinos-container" id="casinos-container">
-                <!-- Sample Casino Cards for Demo -->
-                <div class="casino-card" data-rating="4.9" data-type="online" data-name="Crown Coins">
-                    <div class="casino-header">
-                        <div class="casino-logo">
-                            <img src="https://via.placeholder.com/120x60/4CAF50/white?text=Crown+Coins" alt="Crown Coins">
-                        </div>
-                        <div class="casino-rating">
-                            <span class="rating-badge excellent">4.9</span>
-                            <span class="rating-label">Excellent</span>
-                        </div>
-                    </div>
-                    
-                    <div class="casino-content">
-                        <h3 class="casino-name">Crown Coins</h3>
-                        <div class="casino-bonus">
-                            <span class="bonus-text">Get 200% More Coins on First Purchase</span>
-                        </div>
-                        
-                        <ul class="casino-features">
-                            <li><i class="fas fa-check"></i> 24/7 support, unlike most competitors</li>
-                            <li><i class="fas fa-check"></i> Only sweeps site with 4.7★ iOS app</li>
-                            <li><i class="fas fa-check"></i> Offers Relax Gaming, Pragmatic Play</li>
-                        </ul>
-                        
-                        <div class="casino-actions">
-                            <a href="casino-detail.html?id=1" class="btn btn-primary">Read Review</a>
-                            <a href="#" class="btn btn-secondary">Visit Site</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="casino-card" data-rating="4.7" data-type="sweepstakes" data-name="Stake">
-                    <div class="casino-header">
-                        <div class="casino-logo">
-                            <img src="https://via.placeholder.com/120x60/2196F3/white?text=Stake" alt="Stake">
-                        </div>
-                        <div class="casino-rating">
-                            <span class="rating-badge excellent">4.7</span>
-                            <span class="rating-label">Excellent</span>
-                        </div>
-                    </div>
-                    
-                    <div class="casino-content">
-                        <h3 class="casino-name">Stake</h3>
-                        <div class="casino-bonus">
-                            <span class="bonus-text">Up to 560,000 GC, $56 Stake Cash + 5% Rakeback</span>
-                        </div>
-                        
-                        <ul class="casino-features">
-                            <li><i class="fas fa-check"></i> Exclusive promo code: CASINOORG</li>
-                            <li><i class="fas fa-check"></i> 3,000+ games inc. Stake originals</li>
-                            <li><i class="fas fa-check"></i> Weekly slots battles for 50M GC</li>
-                        </ul>
-                        
-                        <div class="casino-actions">
-                            <a href="casino-detail.html?id=2" class="btn btn-primary">Read Review</a>
-                            <a href="#" class="btn btn-secondary">Visit Site</a>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="casino-card" data-rating="4.6" data-type="online" data-name="Jackpota">
-                    <div class="casino-header">
-                        <div class="casino-logo">
-                            <img src="https://via.placeholder.com/120x60/FF9800/white?text=Jackpota" alt="Jackpota">
-                        </div>
-                        <div class="casino-rating">
-                            <span class="rating-badge excellent">4.6</span>
-                            <span class="rating-label">Excellent</span>
-                        </div>
-                    </div>
-                    
-                    <div class="casino-content">
-                        <h3 class="casino-name">Jackpota</h3>
-                        <div class="casino-bonus">
-                            <span class="bonus-text">80,000 Gold Coins + 40 Sweeps Coins and 75 Free Spins</span>
-                        </div>
-                        
-                        <ul class="casino-features">
-                            <li><i class="fas fa-check"></i> A 200M jackpot on every game</li>
-                            <li><i class="fas fa-check"></i> Get 1,500 free gold coins daily</li>
-                            <li><i class="fas fa-check"></i> Enjoy 700+ exciting games</li>
-                        </ul>
-                        
-                        <div class="casino-actions">
-                            <a href="casino-detail.html?id=3" class="btn btn-primary">Read Review</a>
-                            <a href="#" class="btn btn-secondary">Visit Site</a>
-                        </div>
-                    </div>
-                </div>
+                <!-- Casino cards will be loaded here -->
             </div>
             
             <div class="load-more-container">
@@ -292,12 +203,8 @@
         <div class="container">
             <h2>Casino Games</h2>
             <table class="info-table">
-                <tbody>
-                    <tr><td>Online slots</td></tr>
-                    <tr><td>Online roulette</td></tr>
-                    <tr><td>Online blackjack</td></tr>
-                    <tr><td>Online keno</td></tr>
-                    <tr><td>All casino games</td></tr>
+                <tbody id="games-table-body">
+                    <!-- Games will be loaded here -->
                 </tbody>
             </table>
         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -383,6 +383,17 @@ function initPHPIntegration() {
     
     // Set up AJAX endpoints for PHP communication
     setupAjaxEndpoints();
+
+    // Fetch casino and game data from backend
+    fetch('fetch_casinos.php')
+        .then(response => response.json())
+        .then(data => {
+            loadPHPCasinoData(data);
+            if (data.games) {
+                populateGames(data.games);
+            }
+        })
+        .catch(error => console.error('Failed to load casino data', error));
 }
 
 function updateCasinoData(casinoId, newData) {
@@ -442,6 +453,20 @@ function loadPHPCasinoData(data) {
                 totalElement.textContent = data.totalCount + '+';
             }
         }
+    }
+}
+
+function populateGames(games) {
+    const tbody = document.getElementById('games-table-body');
+    if (tbody) {
+        tbody.innerHTML = '';
+        games.forEach(game => {
+            const tr = document.createElement('tr');
+            const td = document.createElement('td');
+            td.textContent = game.name;
+            tr.appendChild(td);
+            tbody.appendChild(tr);
+        });
     }
 }
 

--- a/test_data.sql
+++ b/test_data.sql
@@ -1,0 +1,25 @@
+-- Sample test data for casino_db
+CREATE DATABASE IF NOT EXISTS casino_db;
+USE casino_db;
+
+-- Insert sample casino with base64 logo
+INSERT INTO casinos (id, name, slug, casino_type, rating, bonus, features, description, logo, status, featured)
+VALUES (
+    1,
+    'Demo Casino',
+    'demo-casino',
+    'online',
+    4.5,
+    '100% Welcome Bonus up to $500',
+    '["Fast payouts", "Great games"]',
+    'Demo Casino is an example used for testing.',
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAAA8CAIAAAAiz+n/AAAGXElEQVR4nO2aa1ATRxzA9yAvklweBPMAAgQS5CUVAgartQJqEYsT0No6nVrH+pyiWOtUO9YZZ5xxprV1bDvT8QMdUPultQ8R1IoVrRZteSMDKJSn8kgiwZAHeZJ+OLgiIka9bsd2f5/+d/u/3c1v9/Zub4K9+pMWIP55/P7tDvxfQKIhgURDAomGBBINCSQaEkg0JJBoSCDRkECiIYFEQwKJhgQSDQkkGhJINCSQaEgg0ZBAoiGBREMCiYYEEg0JJBoSSDQkkGhIINGQoFFeI9OfmRmWkSJRRwoicDrP43Xfd5gGrAMN+sZf714z2o3UNpcm0+zT7CXi/IqCnpFeauunCopFJ4nn7lIXCJiCSefoAbQAGUeaLE6ye+znuy5Q2+LzApWiU6Xq/Zp9GIYBAIx2Y3HzyVpdncPjCAoICsVD5ss0To+TwuaeLzCq/uTIpXMLlx3j0DkAAKvLWnD5fZ1NR0nN/w0om9HZiizCMgDgu7bvZ7AcyVd8nn6EPPR6vTa3rc/SXz1Yc6ajzOa2TU5Ok2myIpZFCSK5dHzUbdPZ9G3D7df7b9y81+T1esF0a/SUM0KmcG3M61GCSPeYp2Wopbj5ZK956joeJ4pdoVgeK4oRMAUer8dgM9TrG890lFE4VygTnSJRk/FvfZW+X4hhGIfOiRaqooWqdPni3Vc/MDstRFG2Yvm2FzaTmTgDxxm4UhCVrcjafXXPbWPbYyvPDMvQKldiAAMAMP1BqjRFJVRuufju5OF8K+7NNdGryUM6oMtxuRyXL4tYcrj6SNVgte+/ZQYoEx2CBxOB3WPX2wwzZHaaunJO55KHHDo7JjDmveQCPpMXzJXlKXOPt5wkirTKHCIoaj5OPEUlbEmsaPai0JfGvGO+9Gq54pWPqz5tMDQsCcvcOGcDAEDAFCwNzyzpKCUSFssXkZZLOkpPtf3AobN3JOXHi+JY/qw9qbu3Xdqut+l99/AoKHuPJteNUZf9iS60umy1urpq3fjESRLPJYu4dJwIzE6z3WMfdY92j3Sf77rw4bWP2of/9KXy0o6zlf3XrS5bSUepxTV+o4TioWTCKtX4kA9YB75uKjI5TP2WgaN1XxDrEsOfkRO54ol+zqOgbEZbXVYegwcACKCxHpusliQvDc9UCqKETCHDnzG5SMgSknH3SPecoAQAwI6k/K2Jm/ss/XfMd1uNrdf6Kk0Oky+9ajTcJGOz08KlcwEAPMb4+LFp7AhexERmkxd4iXjQqjOMGsRsMQAgVhTjS0OPhbIZ3WfuJwIWjSVmz5ohc5Uq98D8/QuCX5SwJVMsAwDofn+PfWFTkdVlJWKGP0PBj1gUunBL4qbCpcdmC6N96dXk8RjzeqaUchkcMjY7zQ9eOEIE+MRd9YxQJrpGV0vGC0MWPCqN5kd7Y/YaIu40deZXFGhLVueczr3UW/Fwcqepc2P51i/rv/ql91Lr0C3SBYvGWh+/zpdekZN0WixOKxnjjAeE8pgTq5brgQF4aihbOs51/Zyn0hIr9WvRqyr7bkz7biRkClkTa0tF7xVix4xhWLRQNW21FpelvOdiec9FAAAGsPXx6/JUWgCAfNI6+9TY3LbukZ4IXjgAIDFoDgYwYmAkbIk4QEzktA7devaGAIUz2uKyfFZ7lHiGcOncTxYdSpe/jDO4DH+GjCNLlap3JOVnyNNNTpPT4yIumR+cJmKJ+Ez+1sRNclz+cJ37NHs3JLydIIqfFTCL5kcTsoQyrpQoGnYMU9LtH9tPE0EwV7YhYT2fyZNxZDuTtxP7W6fHVdZ5jpKGqNyCVw/WHLhxcJe6gM/kB7ICd6l3Tklov9/u9DjPdJSujs4DAMSL4oqzCgEA90aH/his0kjnTckPCghKk2lyldop571e77e3T1HS58t3rkTwwom7RKtcqVWuJIscHsfhmiNU7Vko/qhUp69/p3xLZlhGqlQdyVfgDNwz5iG+3tXrG6sGagAAJ1q+6bcO5ESuCObK7G5Hnb6+uPnE2pg1D9d28PdDabJ5qdKUEG6wiCXyw/yM9uFbxttlnWdbjdTc0QCAoubj1bqabEVWbCC5M7xXb2go7SgbsA5S1Qpl3zoQM4M+/EMCiYYEEg0JJBoSSDQkkGhIINGQQKIhgURDAomGBBINCSQaEkg0JJBoSCDRkECiIYFEQwKJhsRfPGMvhrMsz7gAAAAASUVORK5CYII=',
+    'active',
+    1
+);
+
+-- Insert sample games for the casino
+INSERT INTO games (casino_id, name, game_type, rating) VALUES
+    (1, 'Demo Slots', 'slots', 4.2),
+    (1, 'Demo Roulette', 'roulette', 4.0);
+


### PR DESCRIPTION
## Summary
- seed `casino_db` with demo casino and games, including base64 logo
- add PHP endpoint that outputs casinos and games as JSON
- load casino/game data on the homepage via new JS helpers

## Testing
- `php -l includes/config.php fetch_casinos.php`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68a20ee5f1608332a181b2a95d36c99a