### PR TITLE
Fix features parsing for casino data

### DIFF
--- a/fetch_casinos.php
+++ b/fetch_casinos.php
@@ -14,6 +14,17 @@ try {
     $casinoStmt = $db->query("SELECT id, name, casino_type AS type, rating, bonus, features, description, logo FROM casinos WHERE status = 'active'");
     $casinos = $casinoStmt->fetchAll(PDO::FETCH_ASSOC);
 
+    // Decode JSON fields to proper PHP arrays
+    foreach ($casinos as &$casino) {
+        if (isset($casino['features'])) {
+            $decoded = json_decode($casino['features'], true);
+            $casino['features'] = is_array($decoded) ? $decoded : [];
+        } else {
+            $casino['features'] = [];
+        }
+    }
+    unset($casino);
+
     // Fetch games for all casinos
     $gameStmt = $db->query("SELECT casino_id, name FROM games ORDER BY id");
     $games = $gameStmt->fetchAll(PDO::FETCH_ASSOC);

--- a/js/main.js
+++ b/js/main.js
@@ -331,7 +331,9 @@ function createCasinoCard(data) {
             </div>
             
             <ul class="casino-features">
-                ${data.features.map(feature => `<li><i class="fas fa-check"></i> ${feature}</li>`).join('')}
+                ${(
+                    Array.isArray(data.features) ? data.features : []
+                ).map(feature => `<li><i class="fas fa-check"></i> ${feature}</li>`).join('')}
             </ul>
             
             <div class="casino-actions">


### PR DESCRIPTION
## Summary
- Decode `features` JSON strings to arrays in `fetch_casinos.php`
- Guard feature list rendering in `main.js` to prevent TypeErrors

## Testing
- `php -l fetch_casinos.php`
- `node --check js/main.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a218392e248332a13a828b60040197