### PR TITLE
Add dropdown submenu for Games navigation

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,6 +87,41 @@ body {
     width: 100%;
 }
 
+.nav-item.dropdown {
+    position: relative;
+}
+
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    background: white;
+    list-style: none;
+    padding: 0.5rem 0;
+    margin: 0;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+    min-width: 180px;
+}
+
+.dropdown-link {
+    display: block;
+    padding: 0.5rem 1rem;
+    color: #333;
+    text-decoration: none;
+    white-space: nowrap;
+}
+
+.dropdown-link:hover {
+    background-color: #f1f1f1;
+}
+
+.nav-item.dropdown:hover .dropdown-menu,
+.nav-item.dropdown.open .dropdown-menu {
+    display: block;
+}
+
 .admin-link {
     background: rgba(255, 255, 255, 0.2);
     padding: 0.5rem 1rem;

--- a/index.html
+++ b/index.html
@@ -27,8 +27,16 @@
                     <li class="nav-item">
                         <a href="#" class="nav-link">Sweepstakes Casinos</a>
                     </li>
-                    <li class="nav-item">
-                        <a href="#" class="nav-link">Games</a>
+                    <li class="nav-item dropdown">
+                        <a href="#" class="nav-link dropdown-toggle">Games</a>
+                        <ul class="dropdown-menu">
+                            <li><a href="#" class="dropdown-link">Casino Games</a></li>
+                            <li><a href="#" class="dropdown-link">Online slots</a></li>
+                            <li><a href="#" class="dropdown-link">Online roulette</a></li>
+                            <li><a href="#" class="dropdown-link">Online blackjack</a></li>
+                            <li><a href="#" class="dropdown-link">Online keno</a></li>
+                            <li><a href="#" class="dropdown-link">All casino games</a></li>
+                        </ul>
                     </li>
                     <li class="nav-item">
                         <a href="#" class="nav-link">Bonuses</a>

--- a/js/main.js
+++ b/js/main.js
@@ -44,10 +44,26 @@ function initMobileNav() {
             });
         });
         
-        // Close menu when clicking on links
+        // Close menu when clicking on non-dropdown links
         const navLinks = document.querySelectorAll('.nav-link');
         navLinks.forEach(link => {
-            link.addEventListener('click', () => {
+            link.addEventListener('click', (e) => {
+                const isDropdownToggle = link.classList.contains('dropdown-toggle');
+                if (isDropdownToggle) {
+                    if (window.innerWidth <= 768) {
+                        e.preventDefault();
+                        link.parentElement.classList.toggle('open');
+                    }
+                } else {
+                    navMenu.classList.remove('active');
+                }
+            });
+        });
+
+        // Close menu when clicking dropdown items
+        const dropdownLinks = document.querySelectorAll('.dropdown-link');
+        dropdownLinks.forEach(item => {
+            item.addEventListener('click', () => {
                 navMenu.classList.remove('active');
             });
         });


### PR DESCRIPTION
## Summary
- add "Games" dropdown with links for Casino Games, Online slots, Online roulette, Online blackjack, Online keno, and All casino games
- style new dropdown menu
- support mobile dropdown toggling in navigation script

## Testing
- `npx eslint js/main.js` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npx stylelint css/style.css` *(npm error canceled)*
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23fa59b408332a9dca4629b74b1ca