### PR TITLE
Remove Games dropdown menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,41 +87,6 @@ body {
     width: 100%;
 }
 
-.nav-item.dropdown {
-    position: relative;
-}
-
-.dropdown-menu {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    background: white;
-    list-style: none;
-    padding: 0.5rem 0;
-    margin: 0;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0,0,0,0.1);
-    min-width: 180px;
-}
-
-.dropdown-link {
-    display: block;
-    padding: 0.5rem 1rem;
-    color: #333;
-    text-decoration: none;
-    white-space: nowrap;
-}
-
-.dropdown-link:hover {
-    background-color: #f1f1f1;
-}
-
-.nav-item.dropdown:hover .dropdown-menu,
-.nav-item.dropdown.open .dropdown-menu {
-    display: block;
-}
-
 .admin-link {
     background: rgba(255, 255, 255, 0.2);
     padding: 0.5rem 1rem;

--- a/index.html
+++ b/index.html
@@ -27,17 +27,6 @@
                     <li class="nav-item">
                         <a href="#" class="nav-link">Sweepstakes Casinos</a>
                     </li>
-                    <li class="nav-item dropdown">
-                        <a href="#" class="nav-link dropdown-toggle">Games</a>
-                        <ul class="dropdown-menu">
-                            <li><a href="#" class="dropdown-link">Casino Games</a></li>
-                            <li><a href="#" class="dropdown-link">Online slots</a></li>
-                            <li><a href="#" class="dropdown-link">Online roulette</a></li>
-                            <li><a href="#" class="dropdown-link">Online blackjack</a></li>
-                            <li><a href="#" class="dropdown-link">Online keno</a></li>
-                            <li><a href="#" class="dropdown-link">All casino games</a></li>
-                        </ul>
-                    </li>
                     <li class="nav-item">
                         <a href="#" class="nav-link">Bonuses</a>
                     </li>

--- a/js/main.js
+++ b/js/main.js
@@ -44,26 +44,10 @@ function initMobileNav() {
             });
         });
         
-        // Close menu when clicking on non-dropdown links
+        // Close menu when clicking links
         const navLinks = document.querySelectorAll('.nav-link');
         navLinks.forEach(link => {
-            link.addEventListener('click', (e) => {
-                const isDropdownToggle = link.classList.contains('dropdown-toggle');
-                if (isDropdownToggle) {
-                    if (window.innerWidth <= 768) {
-                        e.preventDefault();
-                        link.parentElement.classList.toggle('open');
-                    }
-                } else {
-                    navMenu.classList.remove('active');
-                }
-            });
-        });
-
-        // Close menu when clicking dropdown items
-        const dropdownLinks = document.querySelectorAll('.dropdown-link');
-        dropdownLinks.forEach(item => {
-            item.addEventListener('click', () => {
+            link.addEventListener('click', () => {
                 navMenu.classList.remove('active');
             });
         });


### PR DESCRIPTION
## Summary
- Remove the Games navigation dropdown and associated links.
- Clean up unused dropdown styles and scripts.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a7664508332a43bb7e47ef9789b