### PR TITLE
Allow anchor navigation

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -347,15 +347,14 @@ function createCasinoCard(data) {
 // Smooth Scrolling
 function initSmoothScrolling() {
     const links = document.querySelectorAll('a[href^="#"]');
-    
+
     links.forEach(link => {
         link.addEventListener('click', function(e) {
-            e.preventDefault();
-            
             const targetId = this.getAttribute('href');
             const targetElement = document.querySelector(targetId);
-            
+
             if (targetElement) {
+                e.preventDefault();
                 targetElement.scrollIntoView({
                     behavior: 'smooth',
                     block: 'start'


### PR DESCRIPTION
## Summary
- Avoid blocking link navigation by preventing default only when a valid anchor target exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8844f55b0833281ab163b612cd34a