### PR TITLE
Prevent error popup on placeholder anchor clicks

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -350,8 +350,13 @@ function initSmoothScrolling() {
 
     links.forEach(link => {
         link.addEventListener('click', function(e) {
-            const targetId = this.getAttribute('href');
-            const targetElement = document.querySelector(targetId);
+            // Extract the ID without the leading '#'
+            const targetId = this.getAttribute('href').slice(1);
+
+            // Skip empty or invalid targets to avoid querySelector errors
+            if (!targetId) return;
+
+            const targetElement = document.getElementById(targetId);
 
             if (targetElement) {
                 e.preventDefault();


### PR DESCRIPTION
## Summary
- guard smooth scrolling against empty hash links by skipping invalid targets
- use `getElementById` to avoid selector syntax errors

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a889584cec8332b9e856586ead37a2